### PR TITLE
Upcoming breaking changes in `loo_compare()` output

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# ubms 1.2.9 (development)
+
+* Updated compatibility with upcoming changes to `loo_compare()` output
+  structure in the `loo` package (> 2.9.0), which now returns a data frame
+  instead of a matrix and includes additional diagnostic columns.
+
 # ubms 1.2.8
 
 * Add probs argument to summary method

--- a/R/fitlist.R
+++ b/R/fitlist.R
@@ -53,8 +53,15 @@ setMethod("modSel", "ubmsFitList", function(object, ...){
   loos <- lapply(object@models, function(x) x@loo)
   elpd <- sapply(loos, function(x) x$estimates[1])
   p_loo <- sapply(loos, function(x) x$estimates[2])
-  compare <- loo::loo_compare(loos)[names(elpd),]
-  out <- data.frame(elpd=elpd, nparam=p_loo, elpd_diff=compare[,1],
-                    se_diff=compare[,2])
+  compare <- loo::loo_compare(loos)
+  if ("model" %in% colnames(compare)) {
+    compare <- compare[match(names(elpd), compare$model),]
+    out <- data.frame(elpd=elpd, nparam=p_loo, elpd_diff=compare[,2],
+                      se_diff=compare[,3])
+  } else {
+    compare <- loo::loo_compare(loos)[names(elpd),]
+    out <- data.frame(elpd=elpd, nparam=p_loo, elpd_diff=compare[,1],
+                      se_diff=compare[,2])
+  }
   out[order(out$elpd_diff, decreasing=TRUE),]
 })


### PR DESCRIPTION
## Description
In the `loo` package, we are making changes to the output structure returned by `loo_compare()` in [PR #300](https://github.com/stan-dev/loo/pull/300). The main changes are a transition from a matrix to a data frame and the addition of several new columns. Here is an example of the updated output structure:

```
> loo_compare(w1, w2)
  model elpd_diff se_diff p_worse diag_diff diag_elpd
 model1       0.0     0.0      NA                    
 model2      -4.1     0.1    1.00   N < 100     
     
Diagnostic flags present.
See ?`loo-glossary` (sections `diag_diff` and `diag_elpd`)
or https://mc-stan.org/loo/reference/loo-glossary.html.
```

More context on the motivation behind these changes can be found in the updated case study ["Uncertainty in Bayesian LOO-CV Model Comparison"](https://users.aalto.fi/~ave/casestudies/LOO_uncertainty/loo_uncertainty.html).

A **reverse dependency check revealed that these changes will affect your package**. To help smooth the transition, I have already reviewed your code and suggest within this PR changes that should keep your package compatible with both the current and the upcoming `loo_compare()` output structure.

I may have missed some additional spots in your code that need updating, so please feel free to point those out and I am happy to help. Thank you and please do not hesitate to reach out if you have any questions or concerns.